### PR TITLE
Updated index.ipynb and added pil examples

### DIFF
--- a/doc/index.ipynb
+++ b/doc/index.ipynb
@@ -11,20 +11,10 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The ImaGen package provides comprehensive support for creating resolution-independent one- and two-dimensional pattern distributions. ImaGen consists of a large library of primarily two-dimensional spatial patterns, including mathematical functions, geometric primitives, and images read from files, along with many ways to combine or select from any other patterns. These patterns can be used in any Python program that needs configurable patterns or streams of patterns.  Basically, as long as the code can accept a Python callable and will call it each time it needs a new pattern, users can then specify any pattern possible in ImaGen's simple declarative pattern language, and the downstream code need not worry about any of the details about how the pattern is specified or generated.  This approach gives users full flexibility about which patterns they wish to use, while relieving the downstream code from having to implement anything about patterns. The detailed examples below should help make this clear."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Usage"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "The ImaGen package provides comprehensive support for creating resolution-independent two-dimensional pattern distributions. ImaGen consists of a large library of spatial patterns, including mathematical functions, geometric primitives, and images read from files, along with many ways to combine or select from any other patterns. These patterns can be used in any Python program that needs configurable patterns or streams of patterns.  Basically, as long as the code can accept a Python callable and will call it each time it needs a new pattern, users can then specify any pattern possible in ImaGen's simple declarative pattern language, and the downstream code need not worry about any of the details about how the pattern is specified or generated.  This approach gives users full flexibility about which patterns they wish to use, while relieving the downstream code from having to implement anything about patterns. The detailed examples below should help make this clear.\n",
+    "\n",
+    "## Usage\n",
+    "\n",
     "To create a pattern, just ``import imagen``, then instantiate one of ImaGen's ``PatternGenerator`` classes.  Each of these classes support various parameters, which are each described in the [Reference Manual](Reference_Manual) or via ``help(``pattern-object-or-class``)``.  Any parameter values specified on instantiation become the defaults for that object:"
    ]
   },
@@ -60,7 +50,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here the parameters ``xdensity`` and ``ydensity`` specified that a continuous 1.0&times;1.0 region in (x,y) space should be sampled on a 5&times;5 grid.  The ``line`` object can now be called repeatedly, with any parameter values specified to override those declared above:"
+    "Here the parameters ``xdensity`` and ``ydensity`` specified that a continuous 1.0&times;1.0 region in (x,y) space should be sampled on a 5&times;5 grid.  The ``line`` object can now be called repeatedly to get new arrays of data, with any parameter values specified to override those declared above:"
    ]
   },
   {
@@ -78,7 +68,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "ImaGen depends only on NumPy, Param, and HoloViews, none of which have any other required dependencies, and it is thus easy to incorporate ImaGen into your own code to generate or use patterns freely.  An optional plotting interface using HoloViews is also available, which provides a convenient way to plot the pattern objects (here using Matplotlib, but also supporting Bokeh):"
+    "As you can see, the results are in the form of a Numpy array, and here we have used very small arrays to avoid generating a lot of numeric output.  For larger arrays, it is convenient to view them as images, which you can do easily if you have the ``PIL`` or ``pillow`` libraries installed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "line.set_param(xdensity=72,ydensity=72,orientation=np.pi/4, thickness=0.1, smoothing=0.02)\n",
+    "\n",
+    "line.pil(orientation=3*np.pi/4)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As you can see, the `.pil()` method accepts the same options as supported elsewhere, making it simple to create the image that you need to generate.  `.pil()` returns a PIL image, which can be exported to files on disk using the methods described in the PIL documentation.\n",
+    "\n",
+    "ImaGen depends only on NumPy, Param, and HoloViews, none of which have any other required dependencies, and it is thus easy to incorporate ImaGen into your own code to generate or use patterns freely. That said, HoloViews supports various plotting libraries, including Matplotlib and Bokeh, and if you have one of those installed then imagen provides a convenient way to plot the pattern objects with axes and labels:"
    ]
   },
   {
@@ -90,7 +100,6 @@
     "import holoviews as hv\n",
     "hv.notebook_extension(\"matplotlib\")\n",
     "\n",
-    "line.set_param(xdensity=72,ydensity=72,orientation=np.pi/4, thickness=0.1, smoothing=0.02)\n",
     "line[:]"
    ]
   },
@@ -105,13 +114,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Dynamic parameter values"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "### Dynamic parameter values\n",
+    "\n",
     "As you can see above, ``PatternGenerator`` objects return different patterns depending on their parameter values. An important feature of these parameter values is that any of them can be set to \"dynamic\" values, which will then result in a different pattern each time (see the [Param package](http://ioam.github.io/param) and its ``numbergen`` module for details). With dynamic parameters, ``PatternGenerators`` provide streams of patterns, not just individual patterns.  For example, let's define a ``SineGrating`` object with a random orientation, collect four of them at different times (using the ``.anim()`` method), and lay them out next to each other (using the ``NdLayout`` class from HoloViews):"
    ]
   },
@@ -155,13 +159,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Composite patterns"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "### Composite patterns\n",
+    "\n",
     "As you can see above, ``PatternGenerator`` objects can also be used as a ``mask`` for another ``PatternGenerator``, which is one simple way to combine them.  \n",
     "\n",
     "``PatternGenerator``s can also be combined directly with each other to create ``Composite`` ``PatternGenerator``s, which can make any possible 2D pattern.  For instance, we can easily sum 10 oriented ``Gaussian`` patterns, each with random positions and orientations, giving a different overall pattern at each time:"
@@ -257,13 +256,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Image patterns"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "### Image patterns\n",
+    "\n",
     "ImaGen can load and manipulate photographic images just like other patterns, apart from them not being resolution independent.  For full functionality this requires the optional PIL or Pillow library, but support for Numpy arrays as images is provided with no further dependencies.  For instance, if you have a database of images (here consisting of only one image for simplicity), you can repeatedly select an image at random from the database using ``Selector``, rotate it randomly if desired, and select a random patch of the image at each time:"
    ]
   },
@@ -288,13 +282,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Applying functions to generated patterns"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "### Applying functions to generated patterns\n",
+    "\n",
     "Once the pattern has been generated, but before it is returned, you can apply any function to the data that you like, via the ``output_fns`` parameter.  A variety of useful ``TransferFn``s are supplied for use as ``output_fns``, such as thresholding functions, normalizing functions (L0, L1, L2, L-infinity, etc.), and convolutions. Any number of these or your own functions (anything that can operate on a 2D Numpy array) can be applied, in order:"
    ]
   },
@@ -319,13 +308,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Multi-channel patterns"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "### Multi-channel patterns\n",
+    "\n",
     "The above examples all show \"single-channel\" ``PatternGenerator`` objects, which are very general and usable for a huge variety of applications, as they are simply Numpy arrays.  \n",
     "\n",
     "``PatternGenerator`` objects can have any number of channels, with each channel generating a Numpy array of the same size.  Multi-channel patterns are used less often, but are particularly useful for generating color images.  Color images loaded by the ``FileImage`` pattern will have four channels, one for the monochrome image (as above), and the other three for the red, green, and blue channels (accessed using *object*``.channels()``).  RGB images can also be constructed by colorizing a monochrome pattern, or out of combinations of any of the other patterns, using the ``ComposeChannels`` object:"
@@ -346,13 +330,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Pattern types provided"
+    "Three- or four-channel patterns support ``.pil()``, generating RGB or RGBA color images."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ig.ComposeChannels(generators=[ig.Line(orientation=np.pi/2),ig.Ring(),ig.SquareGrating(),ig.Disk()]).pil()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "## Pattern types provided\n",
+    "\n",
     "\n",
     "Below are shown examples of each of the pattern types currently provided, using their default parameter values. Very many different parameter values can be chosen, to produce a much wider range of patterns, and of course new patterns can be created as ``Composite`` patterns as shown above.  "
    ]
@@ -382,13 +377,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Extending ImaGen"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
+    "## Extending ImaGen\n",
+    "\n",
     "New ``Composite`` patterns can be created easily without writing new classes, as shown above.  If you want to create a new non-composite type, you can simply define a new class inheriting from ``PatternGenerator``, then override ``self.function()`` to draw the pattern, and declare any new parameter(s) used by ``self.function()``.  The new pattern can then be rotated, scaled, translated, etc. automatically, with no further coding, it will support dynamic pattern streams automatically, and it can be combined with any existing or new pattern to make new ``Composite`` patterns.  If you don't want the automatic scaling, rotating, etc. (e.g. for a whole-field pattern like a new type of random distribution), you can override ``self.__call__`` instead of ``self.function()``, which allows you to do anything that returns a Numpy array of the requested size.  See the many classes in ``imagen/__init__.py`` and ``imagen/random.py`` for examples of each approach."
    ]
   }


### PR DESCRIPTION
The index notebook had some outdated info; also added examples of using the new ``.pil()`` method.