### PR TITLE
Replace key_dimensions with k_dims

### DIFF
--- a/imagen/patterngenerator.py
+++ b/imagen/patterngenerator.py
@@ -339,7 +339,7 @@ class PatternGenerator(param.Parameterized):
             label = time_fn.label if hasattr(time_fn, 'label') else 'Time'
 
         unit = time_fn.unit if (not unit and hasattr(time_fn, 'unit')) else unit
-        vmap = HoloMap(key_dimensions=[Dimension(label, unit=unit if unit else '')])
+        vmap = HoloMap(kdims=[Dimension(label, unit=unit if unit else '')])
 
         self.state_push()
         with time_fn as t:


### PR DESCRIPTION
This bug was causing a lot of errors when running models in topographica.
Used kdims, not k_dims as in the comment.